### PR TITLE
cuda 11.4 -> 11.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.0-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 RUN apt update
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \


### PR DESCRIPTION
# Reason
```
ERROR: failed to solve: nvidia/cuda:11.4.0-cudnn8-devel-ubuntu20.04: docker.io/nvidia/cuda:11.4.0-cudnn8-devel-ubuntu20.04: not found
```
![image](https://github.com/nagadomi/waifu2x-caffe-ubuntu/assets/15166740/91665352-377a-46c1-80c6-80c195896d66)